### PR TITLE
Make DefaultMediaSourceFactory implements IMediaSourceFactory (Xamarin branch)

### DIFF
--- a/ExoPlayer.Core/Additions/BaseMediaSource.cs
+++ b/ExoPlayer.Core/Additions/BaseMediaSource.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using Android.Content;
 
 namespace Com.Google.Android.Exoplayer2.Source
 {
@@ -8,9 +9,15 @@ namespace Com.Google.Android.Exoplayer2.Source
     // Metadata.xml XPath class reference: path="/api/package[@name='com.google.android.exoplayer2.source']/class[@name='BaseMediaSource']"
     public abstract partial class BaseMediaSource : global::Java.Lang.Object, global::Com.Google.Android.Exoplayer2.Source.IMediaSource
     {
-
         //public abstract global::Java.Lang.Object Tag { get; }
     }
+
+    public partial class DefaultMediaSourceFactory : global::Com.Google.Android.Exoplayer2.Source.IMediaSourceFactory
+    {
+        //public abstract global::Java.Lang.Object Tag { get; }
+        
+    }
+
 
     internal partial class BaseMediaSourceInvoker : BaseMediaSource
     {


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Make DefaultMediaSourceFactory implements IMediaSourceFactory 

### :arrow_heading_down: What is the current behavior?
Its missing this interface

### :new: What is the new behavior (if this is a feature change)?
I add this interface and let us customize the player by using it like this :

```cs
DefaultExtractorsFactory extractorsFactory =
    new DefaultExtractorsFactory()
        .SetMp3ExtractorFlags(Mp3Extractor.FlagEnableConstantBitrateSeeking);
var mediaSourceFactory = new DefaultMediaSourceFactory(Application.Context, extractorsFactory);
player = exoPlayerBuilder
    .SetMediaSourceFactory(mediaSourceFactory)
    ?.Build();
```

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs
#150  : MonoAndroid bindings issues: IMediaSourceFactory and DownloadService


### :thinking: Checklist before submitting

- [x ] All projects build
- [x ] Follows style guide lines 
- [ x] Relevant documentation was updated
- [x ] Rebased onto current xamarin
